### PR TITLE
Feat: 마이 페이지 관련 오류 수정

### DIFF
--- a/src/pages/Ask.tsx
+++ b/src/pages/Ask.tsx
@@ -14,18 +14,19 @@ import PATH from '@src/constants/pathConst'
 const Ask = () => {
   const [questions, setQuestions] = useState<QuestionGetTypes[]>([])
   const [adminQuestions, setAdminQuestions] = useState<QuestionGetTypes[]>([])
+  const userInfo = useSelector((state: RootState) => state.userInfo)
 
   useEffect(() => {
     const fetchData = async () => {
       const response = await getQuestion(1)
       setQuestions(response?.data.content)
-      const adminResponse = await getAdminQuestion(1)
-      setAdminQuestions(adminResponse?.data.content)
+      if (userInfo.role === '관리자') {
+        const adminResponse = await getAdminQuestion(1)
+        setAdminQuestions(adminResponse?.data.content)
+      }
     }
     fetchData()
   }, [])
-
-  const userInfo = useSelector((state: RootState) => state.userInfo)
 
   const isPC = useMediaQuery({
     query: '(min-width: 450px)',

--- a/src/pages/MyPageDetail.tsx
+++ b/src/pages/MyPageDetail.tsx
@@ -7,8 +7,7 @@ import { useLocation } from 'react-router'
 import { useMediaQuery } from 'react-responsive'
 import Inner from '@src/components/Inner'
 import Board from '@src/components/Board'
-import { getMyPost } from '@src/api/authApi'
-import { useGetWishlistQuery } from '@src/store/slices/wishlistSlice'
+import { getMyPost, getWishlist } from '@src/api/authApi'
 
 const MyPageDetail = () => {
   const [page, setPage] = useState<number>(1)
@@ -16,9 +15,8 @@ const MyPageDetail = () => {
   const { state }: { state: number } = useLocation()
   const [activeMenu, setActiveMenu] = useState<number>(state)
   const [posts, setPosts] = useState<POST_TYPE[]>([])
-  const { data } = useGetWishlistQuery(page)
-  const wishlists = data ? data.data.content : []
   const menuLists = ['양도', '좋아요', '댓글']
+  const [wishlists, setWishlists] = useState([])
 
   const activeList = (activeMenu: number, screen: string) => {
     if (activeMenu === 0 && screen === 'mobile') {
@@ -41,9 +39,11 @@ const MyPageDetail = () => {
     const fetchData = async () => {
       const postsResponse = await getMyPost(1)
       setPosts(postsResponse?.data)
+      const wishlistResponse = await getWishlist(1)
+      setWishlists(wishlistResponse?.data)
+      setTotalPage(Math.ceil(wishlistResponse?.element / 10))
     }
     fetchData()
-    setTotalPage(Math.ceil(data?.numberOfElements / 10))
   }, [])
 
   const isPC = useMediaQuery({

--- a/src/store/config.tsx
+++ b/src/store/config.tsx
@@ -1,4 +1,4 @@
-import { combineReducers, configureStore, Middleware, Dispatch, AnyAction } from '@reduxjs/toolkit'
+import { combineReducers, configureStore } from '@reduxjs/toolkit'
 import { persistStore, persistReducer } from 'redux-persist'
 import storage from 'redux-persist/lib/storage'
 import testSlice from './slices/testSlice'
@@ -6,7 +6,7 @@ import authReducer from './slices/authSlice'
 import searchVlaue from './slices/searchVlaueSlice'
 import postData from './slices/postDataSlice'
 import infoSlice from './slices/infoSlice'
-import wishlistSlice, { wishlistApi } from './slices/wishlistSlice'
+import wishlistSlice from './slices/wishlistSlice'
 import { setupListeners } from '@reduxjs/toolkit/dist/query'
 import searchBox from './slices/searchChkSlice'
 import commentData from './slices/commentSlice'
@@ -18,7 +18,6 @@ const rootReducer = combineReducers({
   postData: postData.reducer,
   userInfo: infoSlice.reducer,
   wishlist: wishlistSlice.reducer,
-  [wishlistApi.reducerPath]: wishlistApi.reducer,
   searchBox: searchBox.reducer,
   commentData: commentData.reducer,
 })
@@ -35,7 +34,7 @@ const store = configureStore({
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({
       serializableCheck: false,
-    }).concat([wishlistApi.middleware as Middleware<Dispatch<AnyAction>, RootState>]),
+    }),
 })
 
 setupListeners(store.dispatch)

--- a/src/store/slices/wishlistSlice.tsx
+++ b/src/store/slices/wishlistSlice.tsx
@@ -1,29 +1,4 @@
 import { createSlice } from '@reduxjs/toolkit'
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
-
-const BASE_URL = import.meta.env.VITE_BASE_URL
-const storage = JSON.parse(localStorage.getItem('persist:root') as string)
-const token = JSON.parse(storage.accessToken)
-
-const baseQuery = fetchBaseQuery({
-  baseUrl: BASE_URL,
-  prepareHeaders: (headers) => {
-    headers.set('Authorization', `Bearer ${token.accessToken}`)
-    return headers
-  },
-})
-
-export const wishlistApi = createApi({
-  reducerPath: 'wishlistApi',
-  baseQuery,
-  tagTypes: ['Wishlist'],
-  endpoints: (builder) => ({
-    getWishlist: builder.query({
-      query: (page: number = 1) => `/my-page/wish-list/${page}`,
-      providesTags: [{ type: 'Wishlist', id: 'WISHLIST' }],
-    }),
-  }),
-})
 
 export const wishlistSlice = createSlice({
   name: 'wishlist',
@@ -38,5 +13,4 @@ export const wishlistSlice = createSlice({
 })
 
 export const { SET_WISHLIST } = wishlistSlice.actions
-export const { useGetWishlistQuery } = wishlistApi
 export default wishlistSlice


### PR DESCRIPTION
## 🔊 팀원들에게 알릴 사항

- 좋아요 목록을 부를 때 rtk-query 사용하던 것을 수정, config.ts에도 오류 사라졌습니다.
- 마이 페이지에서 목록 부르는 부분에 페이징 하여야 합니다.

## 💸 작업 내용

- 마이 페이지 좋아요 목록을 부르는 부분 수정
- 1:1 문의 페이지에서 관리자가 아닐 때에도 관리자 api를 호출하여 오류가 뜨는 것을 수정하였습니다.
