### PR TITLE
Feat: 상세 게시글 > 회원 정보 이동 페이지 기능 구현

### DIFF
--- a/src/api/authApi.tsx
+++ b/src/api/authApi.tsx
@@ -361,10 +361,11 @@ export const getMyReply = async (page: number) => {
 // 회원 게시글 조회
 export const getUserPost = async (page: number, memberId: string) => {
   try {
-    const response = await publicApi(`member-inquery/${memberId}/${page}`, { method: 'GET' })
+    const response = await publicApi(`member-inquiry/${memberId}/${page}`, { method: 'GET' })
     return {
       status: response.status,
       data: response.data.data.content,
+      lastPage: response.data.data.last,
     }
   } catch (error) {
     if (isAxiosError<IResponseErrorType>(error)) {

--- a/src/api/authApi.tsx
+++ b/src/api/authApi.tsx
@@ -357,3 +357,20 @@ export const getMyReply = async (page: number) => {
     }
   }
 }
+
+// 회원 게시글 조회
+export const getUserPost = async (page: number, memberId: string) => {
+  try {
+    const response = await publicApi(`member-inquery/${memberId}/${page}`, { method: 'GET' })
+    return {
+      status: response.status,
+      data: response.data.data.content,
+    }
+  } catch (error) {
+    if (isAxiosError<IResponseErrorType>(error)) {
+      return {
+        status: error.response?.data.state,
+      }
+    }
+  }
+}

--- a/src/api/boardApi.tsx
+++ b/src/api/boardApi.tsx
@@ -15,7 +15,6 @@ export const getSearchPostList = async (values: SearchValueTypes, page = 1) => {
       }&districtNames=${values.district.join()}`
     )
     .then((res) => {
-      console.log(res.data)
       return res.data.data
     })
     .catch((err) => {
@@ -28,7 +27,6 @@ export const getPostDetail = async (userId: number, loginVal: boolean) => {
 
   return await Instance.get(`/detail/${userId}`)
     .then((res) => {
-      console.log(res.data.data)
       return res.data.data
     })
     .catch((err) => {
@@ -49,7 +47,6 @@ export const delPost = async (boardId: number | undefined) => {
 
 export const getComment = async (boardId: number, page: number, loginVal: boolean) => {
   const Instance = loginVal ? privateApi : publicApi
-  console.log(page)
   return await Instance.get(`comment-lookup/${boardId}/${page}`)
     .then((res) => {
       return res.data.data
@@ -60,7 +57,6 @@ export const getComment = async (boardId: number, page: number, loginVal: boolea
 }
 
 export const postComment = async (boardId: number, comment: string, parentId?: number) => {
-  console.log(parentId)
   return await privateApi
     .post('comment/write', {
       commentContent: comment,
@@ -68,7 +64,6 @@ export const postComment = async (boardId: number, comment: string, parentId?: n
       parentId: parentId,
     })
     .then((res) => {
-      console.log(res)
       return res
     })
     .catch((err) => {

--- a/src/pages/BoardDetails.tsx
+++ b/src/pages/BoardDetails.tsx
@@ -112,7 +112,7 @@ const BoardDetails = () => {
               </Mobile>
               <div>
                 <p>
-                  <span className="user_name">
+                  <span className="user_name" onClick={() => navigate(`/profile/${detailData.memberId}`)}>
                     {detailData.memberName} {detailData.memberId}
                   </span>
                   <span className="view">조회수 {detailData.viewCount}</span>
@@ -278,6 +278,7 @@ const TitleBox = styled.div`
       width: 100%;
       display: block;
       font-size: 14px;
+      cursor: pointer;
     }
 
     .view,

--- a/src/pages/BoardDetails.tsx
+++ b/src/pages/BoardDetails.tsx
@@ -112,7 +112,14 @@ const BoardDetails = () => {
               </Mobile>
               <div>
                 <p>
-                  <span className="user_name" onClick={() => navigate(`/profile/${detailData.memberId}`)}>
+                  <span
+                    className="user_name"
+                    onClick={() =>
+                      navigate(`/profile/${detailData.memberId}`, {
+                        state: { memberName: detailData.memberName, memberId: detailData.memberId },
+                      })
+                    }
+                  >
                     {detailData.memberName} {detailData.memberId}
                   </span>
                   <span className="view">조회수 {detailData.viewCount}</span>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -5,13 +5,13 @@ import styled from 'styled-components'
 import { COLORS, FONT } from '@src/globalStyles'
 import MBoardList from '@src/components/MBoardList'
 import { useState, useEffect } from 'react'
-import { getMyPost } from '@src/api/authApi'
+import { getUserPost } from '@src/api/authApi'
 
 const Profile = () => {
   const [posts, setPosts] = useState<POST_TYPE[]>([])
   useEffect(() => {
     const fetchData = async () => {
-      const response = await getMyPost(1)
+      const response = await getUserPost(1, 'dm@test.com')
       setPosts(response?.data)
     }
     fetchData()

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -6,16 +6,49 @@ import { COLORS, FONT } from '@src/globalStyles'
 import MBoardList from '@src/components/MBoardList'
 import { useState, useEffect } from 'react'
 import { getUserPost } from '@src/api/authApi'
+import { useLocation } from 'react-router'
+import { useInView } from 'react-intersection-observer'
 
 const Profile = () => {
+  const { state } = useLocation()
+  const { pathname } = useLocation()
+  const memberName = state.memberName
+  const memberId = pathname.slice(9)
+
   const [posts, setPosts] = useState<POST_TYPE[]>([])
-  useEffect(() => {
-    const fetchData = async () => {
-      const response = await getUserPost(1, 'dm@test.com')
-      setPosts(response?.data)
+
+  const [ref, inView] = useInView()
+  const [page, setPage] = useState(1)
+  const [isLoading, setIsLoading] = useState(false)
+  const [lastPage, setLastPage] = useState(false)
+
+  const getPost = async () => {
+    try {
+      setIsLoading(true)
+      const response = await getUserPost(page, memberId)
+      if (page === 1) setPosts(response?.data)
+      else setPosts((prev) => [...prev, ...response?.data])
+
+      if (response?.lastPage) setLastPage(true)
+      else setLastPage(false)
+    } catch (error) {
+      alert(error)
+    } finally {
+      setIsLoading(false)
     }
-    fetchData()
-  }, [])
+  }
+
+  useEffect(() => {
+    getPost()
+  }, [page])
+
+  useEffect(() => {
+    if (inView && !isLoading && !lastPage) {
+      console.log('페이지 추가')
+      setPage((prev) => prev + 1)
+    }
+  }, [inView, isLoading])
+
   const isPC = useMediaQuery({ query: '(min-width: 834px' })
   return (
     <>
@@ -23,17 +56,17 @@ const Profile = () => {
         <Inner>
           <TopStyle screen="pc">
             <div className="title">
-              <span>김필드 1412</span> 님의 게시물
+              <span>{memberName}</span> 님의 게시물
             </div>
             <RoleButton screen="pc">관리자 등록</RoleButton>
           </TopStyle>
-          <Board data={[]} message={'작성한 게시물이 없습니다.'} />
+          <Board data={posts} message={'작성한 게시물이 없습니다.'} />
         </Inner>
       ) : (
         <div>
           <TopStyle screen="mobile">
             <div className="title">
-              <span>김필드 1412</span> 님의 게시물
+              <span>{memberName}</span> 님의 게시물
             </div>
             <RoleButton screen="mobile">관리자 등록</RoleButton>
           </TopStyle>
@@ -43,6 +76,7 @@ const Profile = () => {
             ) : (
               <div>작성한 게시물이 없습니다.</div>
             )}
+            <div ref={ref}></div>
           </PostContainer>
         </div>
       )}


### PR DESCRIPTION
## 🔊 팀원들에게 알릴 사항

- useLoaction에 있는 state를 활용하여 회원 닉네임을 가지고 오는데 뒤로 가기를 누를 시에 오류가 있습니다.
- 마이 페이지는 작업하지 않았는데 댓글 불러오는 부분에 오류가 있습니다. 다음 pr에 수정하도록 하겠습니다.
- boardDetail 파일에서 css가 잘 먹지 않는 부분이 있습니다. 이 부분도 다시 확인해 보겠습니다.

## 💸 작업 내용

- #78 
- 상세 게시글에서 글을 작성한 사람의 닉네임을 누르면 프로필로 이동
- 해당 회원이 작성한 게시글을 불러오며, 무한 스크롤로 구현

