### PR TITLE
Feat: 문의글 기능, 상세 페이지에서 블라인드 기능 추가

### DIFF
--- a/src/api/authApi.tsx
+++ b/src/api/authApi.tsx
@@ -326,7 +326,7 @@ export const getWishlist = async (page: number) => {
       status: response.status,
       message: response.data.message,
       data: response.data.data.content,
-      totalPages: response.data,
+      totalPages: response.data.data.totalPages,
       totalElements: response.data.data.totalElements,
     }
   } catch (error) {

--- a/src/api/authApi.tsx
+++ b/src/api/authApi.tsx
@@ -320,11 +320,12 @@ export const getWishlist = async (page: number) => {
     const response = await privateApi(`/my-page/wish-list/${page}`, {
       method: 'GET',
     })
+    console.log(response)
     return {
       status: response.status,
       message: response.data.message,
       data: response.data.data.content,
-      totalPages: response.data.data.totalPages,
+      totalPages: response.data,
       totalElements: response.data.data.totalElements,
     }
   } catch (error) {

--- a/src/api/boardApi.tsx
+++ b/src/api/boardApi.tsx
@@ -145,3 +145,14 @@ export const addTransactionStatus = async (commentId: number) => {
       console.log(err)
     })
 }
+
+export const blindBoard = async (boardId: number) => {
+  return await privateApi
+    .put(`/admin/board/blind/${boardId}`)
+    .then(() => {
+      alert('블라인드 처리하였습니다.')
+    })
+    .catch((error) => {
+      console.log(error)
+    })
+}

--- a/src/api/getApi.tsx
+++ b/src/api/getApi.tsx
@@ -12,26 +12,26 @@ export const getUserInfo = async () => {
 
 // 관리자 문의글 전체 조회
 export const getAdminQuestion = async (page: number) => {
-  try {
-    const response = await privateApi.get(`/admin/question-list/${page}`)
-    return {
-      data: response.data.data,
-    }
-  } catch (error) {
-    console.log(error)
-  }
+  return await privateApi
+    .get(`/admin/question-list/${page}`)
+    .then((response) => {
+      return response.data.data
+    })
+    .catch((error) => {
+      console.log(error)
+    })
 }
 
 // 내 문의글 조회
 export const getQuestion = async (page: number) => {
-  try {
-    const response = await privateApi.get(`/question/inquiry/${page}`)
-    return {
-      data: response.data.data,
-    }
-  } catch (error) {
-    console.log(error)
-  }
+  return await privateApi
+    .get(`/question/inquiry/${page}`)
+    .then((response) => {
+      return response.data.data
+    })
+    .catch((error) => {
+      console.log(error)
+    })
 }
 
 // 문의글 상세 조회

--- a/src/api/userApi.tsx
+++ b/src/api/userApi.tsx
@@ -1,0 +1,38 @@
+import { isAxiosError } from 'axios'
+import { privateApi } from './Instance'
+
+// 승급
+export const promoteUser = async (memberId: string) => {
+  try {
+    const response = await privateApi(`/admin/promote?memberId=${memberId}`, {
+      method: 'PUT',
+    })
+    return {
+      status: response.status,
+    }
+  } catch (error) {
+    if (isAxiosError<IResponseErrorType>(error)) {
+      return {
+        status: error.response?.data.state,
+      }
+    }
+  }
+}
+
+// 강등
+export const demoteUser = async (memberId: string) => {
+  try {
+    const response = await privateApi(`/admin/demote?memberId=${memberId}`, {
+      method: 'PUT',
+    })
+    return {
+      status: response.status,
+    }
+  } catch (error) {
+    if (isAxiosError<IResponseErrorType>(error)) {
+      return {
+        status: error.response?.data.state,
+      }
+    }
+  }
+}

--- a/src/components/MyPage/CommentLists.tsx
+++ b/src/components/MyPage/CommentLists.tsx
@@ -26,36 +26,38 @@ const CommentLists = ({ screen }: IProps) => {
   }
   return (
     <Container screen={screen}>
-      {comments.length ? (
-        comments.map((comment) => (
-          <CommentBox key={comment.commentId}>
-            <BoardTitle screen={screen}>{comment.title}</BoardTitle>
-            <Content screen={screen}>{comment.commentContent}</Content>
-            <Des screen={screen}>
-              <div>
-                <img src="/calendar.svg" alt="달력" />
-                <span>{comment.commentUpDate.slice(0, 10)}</span>
-              </div>
-              <div>
-                <img src="/chat_bubble.svg" alt="댓글" />
-                <span>{comment.children.length}</span>
-              </div>
-            </Des>
-          </CommentBox>
-        ))
+      {comments?.length ? (
+        <>
+          {comments?.map((comment) => (
+            <CommentBox key={comment.commentId}>
+              <BoardTitle screen={screen}>{comment.title}</BoardTitle>
+              <Content screen={screen}>{comment.commentContent}</Content>
+              <Des screen={screen}>
+                <div>
+                  <img src="/calendar.svg" alt="달력" />
+                  <span>{comment.commentUpDate.slice(0, 10)}</span>
+                </div>
+                <div>
+                  <img src="/chat_bubble.svg" alt="댓글" />
+                  <span>{comment.children.length}</span>
+                </div>
+              </Des>
+            </CommentBox>
+          ))}
+          <Paginate screen={screen}>
+            <ReactPaginate
+              previousLabel="<"
+              nextLabel=">"
+              onPageChange={handlePage}
+              breakLabel="..."
+              pageCount={totalPage}
+              className="paginate"
+            />
+          </Paginate>
+        </>
       ) : (
         <NoComment>댓글이 없습니다.</NoComment>
       )}
-      <Paginate screen={screen}>
-        <ReactPaginate
-          previousLabel="<"
-          nextLabel=">"
-          onPageChange={handlePage}
-          breakLabel="..."
-          pageCount={totalPage}
-          className="paginate"
-        />
-      </Paginate>
     </Container>
   )
 }

--- a/src/pages/Ask.tsx
+++ b/src/pages/Ask.tsx
@@ -27,7 +27,7 @@ const Ask = () => {
       if (page === 1) setQuestions(response.content)
       else setQuestions((prev) => [...prev, ...response.content])
 
-      if (response.lastPage) setLastPage(true)
+      if (response.last) setLastPage(true)
       else setLastPage(false)
     } catch (error) {
       alert(error)
@@ -43,7 +43,7 @@ const Ask = () => {
       if (page === 1) setQuestions(response.content)
       else setQuestions((prev) => [...prev, ...response.content])
 
-      if (response.lastPage) setLastPage(true)
+      if (response.last) setLastPage(true)
       else setLastPage(false)
     } catch (error) {
       alert(error)

--- a/src/pages/BoardDetails.tsx
+++ b/src/pages/BoardDetails.tsx
@@ -96,15 +96,15 @@ const BoardDetails = () => {
               </div>
               <div>
                 <p className="date">
-                  {detailData.districtName} {dateFormat(detailData.startTime || '')}
+                  <PC>예약일</PC> {dateFormat(detailData.startTime || '')}
                 </p>
                 <PC>
-                  <p className="price">{detailData.price.toLocaleString()} 원</p>
+                  <p className="price">{detailData.price.toLocaleString()}</p>
                 </PC>
               </div>
               <Mobile>
                 <div>
-                  <p className="price">{detailData.price.toLocaleString()} 원</p>
+                  <p className="price">{detailData.price.toLocaleString()}</p>
                   <button onClick={() => likePostFn(detailData.boardId, detailData.likeBoard)}>
                     <BigHart size="20" color={likeState ? '#5FCA7B' : ''} />
                   </button>
@@ -189,6 +189,7 @@ const BoardDetails = () => {
     </ThemeProvider>
   )
 }
+
 const Container = styled.div`
   max-width: 834px;
   margin: 32px auto 0;
@@ -200,6 +201,7 @@ const Container = styled.div`
     margin: 0 auto;
   }
 `
+
 const TitleBox = styled.div`
   padding: 0 20px;
   display: flex;

--- a/src/pages/BoardDetails.tsx
+++ b/src/pages/BoardDetails.tsx
@@ -1,4 +1,4 @@
-import { addTransactionStatus, delLikeBoard, getPostDetail, postLikeBoard } from '@src/api/boardApi'
+import { addTransactionStatus, blindBoard, delLikeBoard, getPostDetail, postLikeBoard } from '@src/api/boardApi'
 import { BigHart, Harticon, MoreIcon } from '@src/constants/icons'
 import theme from '@src/constants/theme'
 import { dateFormat, handleImgError, randomImages } from '@src/hooks/utils'
@@ -18,6 +18,8 @@ const BoardDetails = () => {
   const [moreBtnChk, setMoreBtnChk] = useState(false)
   const [likeState, setLikeState] = useState(detailData?.likeBoard)
   const authenticated = useSelector((state: RootState) => state.accessToken.authenticated)
+  const userInfo = useSelector((state: RootState) => state.userInfo)
+
   const getDetailData = async () => {
     try {
       const postDetailData = await getPostDetail(Number(boardId.boardId), authenticated)
@@ -47,6 +49,14 @@ const BoardDetails = () => {
     }
   }
 
+  const blindFn = async () => {
+    try {
+      await blindBoard(Number(boardId))
+    } catch (error) {
+      console.log(error)
+    }
+  }
+
   useEffect(() => {
     getDetailData()
   }, [boardId])
@@ -64,6 +74,63 @@ const BoardDetails = () => {
       document.body.removeEventListener('click', outClickFn)
     }
   })
+
+  const moreBtnHandler = (role: string, myBoard: boolean) => {
+    if (role === '관리자' && myBoard) {
+      return (
+        <>
+          <li>
+            <button
+              onClick={() =>
+                window.confirm('양도 완료 상태로 변경하시겠습니까?') && addTransactionStatus(detailData?.boardId)
+              }
+            >
+              양도 완료하기
+            </button>
+          </li>
+          <li>
+            <button onClick={() => window.confirm('정말 삭제하시겠습니까?') && delPostFn(detailData?.boardId)}>
+              삭제
+            </button>
+          </li>
+          <li>
+            <button onClick={() => navigate(`/edit/${boardId.boardId}`, { state: { data: detailData } })}>수정</button>
+          </li>
+          <li>
+            <button onClick={() => window.confirm('블라인드 처리하시겠습니까?') && blindFn()}>블라인드</button>
+          </li>
+        </>
+      )
+    } else if (role === '관리자' && !myBoard) {
+      return (
+        <li>
+          <button onClick={() => window.confirm('블라인드 처리하시겠습니까?') && blindFn()}>블라인드</button>
+        </li>
+      )
+    } else if (role !== '관리자' && myBoard) {
+      return (
+        <>
+          <li>
+            <button
+              onClick={() =>
+                window.confirm('양도 완료 상태로 변경하시겠습니까?') && addTransactionStatus(detailData?.boardId)
+              }
+            >
+              양도 완료하기
+            </button>
+          </li>
+          <li>
+            <button onClick={() => window.confirm('정말 삭제하시겠습니까?') && delPostFn(detailData?.boardId)}>
+              삭제
+            </button>
+          </li>
+          <li>
+            <button onClick={() => navigate(`/edit/${boardId.boardId}`, { state: { data: detailData } })}>수정</button>
+          </li>
+        </>
+      )
+    }
+  }
 
   return (
     <ThemeProvider theme={theme}>
@@ -127,7 +194,7 @@ const BoardDetails = () => {
                     <Harticon size="14" /> {detailData.wishCount}
                   </span>
                 </p>
-                {detailData.myBoard && (
+                {(detailData.myBoard || userInfo.role === '관리자') && (
                   <button
                     className="more_btn"
                     onClick={(e) => {
@@ -138,30 +205,7 @@ const BoardDetails = () => {
                     <MoreIcon />
                   </button>
                 )}
-                {moreBtnChk && (
-                  <ul className="more_menu">
-                    <li>
-                      <button
-                        onClick={() =>
-                          window.confirm('양도 완료 상태로 변경하시겠습니까?') &&
-                          addTransactionStatus(detailData.boardId)
-                        }
-                      >
-                        양도 완료하기
-                      </button>
-                    </li>
-                    <li>
-                      <button onClick={() => window.confirm('정말 삭제하시겠습니까?') && delPostFn(detailData.boardId)}>
-                        삭제
-                      </button>
-                    </li>
-                    <li>
-                      <button onClick={() => navigate(`/edit/${boardId.boardId}`, { state: { data: detailData } })}>
-                        수정
-                      </button>
-                    </li>
-                  </ul>
-                )}
+                {moreBtnChk && <ul className="more_menu">{moreBtnHandler(userInfo.role, detailData.myBoard)}</ul>}
               </div>
             </TitleBox>
             <ContentBox>
@@ -321,7 +365,7 @@ const TitleBox = styled.div`
     background: #fff;
     border: 1px solid #ddd;
     width: 120px;
-    height: 120px;
+    /* height: 120px; */
     padding: 20px;
     box-sizing: border-box;
     font-size: 14px;

--- a/src/pages/BoardDetails.tsx
+++ b/src/pages/BoardDetails.tsx
@@ -82,7 +82,7 @@ const BoardDetails = () => {
           <li>
             <button
               onClick={() =>
-                window.confirm('양도 완료 상태로 변경하시겠습니까?') && addTransactionStatus(detailData?.boardId)
+                window.confirm('양도 완료 상태로 변경하시겠습니까?') && addTransactionStatus(detailData?.boardId || 0)
               }
             >
               양도 완료하기
@@ -113,7 +113,7 @@ const BoardDetails = () => {
           <li>
             <button
               onClick={() =>
-                window.confirm('양도 완료 상태로 변경하시겠습니까?') && addTransactionStatus(detailData?.boardId)
+                window.confirm('양도 완료 상태로 변경하시겠습니까?') && addTransactionStatus(detailData?.boardId || 0)
               }
             >
               양도 완료하기

--- a/src/pages/MyPageDetail.tsx
+++ b/src/pages/MyPageDetail.tsx
@@ -145,7 +145,6 @@ const MyPageDetail = () => {
     ;(state === 0 || state === 1 || state === 2) && setActiveMenu(state)
     postData()
     wishlistData()
-    console.log(state)
   }, [state])
 
   const isPC = useMediaQuery({

--- a/src/pages/MyPageDetail.tsx
+++ b/src/pages/MyPageDetail.tsx
@@ -153,6 +153,7 @@ const MyPageDetail = () => {
 
   const handlePage = (event: { selected: number }) => {
     postData(event.selected + 1)
+    wishlistData(event.selected + 1)
   }
 
   return (

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -8,6 +8,9 @@ import { useState, useEffect } from 'react'
 import { getUserPost } from '@src/api/authApi'
 import { useLocation } from 'react-router'
 import { useInView } from 'react-intersection-observer'
+import { useSelector } from 'react-redux'
+import { RootState } from '@src/store/config'
+// import { promoteUser, demoteUser } from '@src/api/userApi'
 
 const Profile = () => {
   const { state } = useLocation()
@@ -27,6 +30,7 @@ const Profile = () => {
       setIsLoading(true)
       const response = await getUserPost(page, memberId)
       if (page === 1) setPosts(response?.data)
+      // eslint-disable-next-line no-unsafe-optional-chaining
       else setPosts((prev) => [...prev, ...response?.data])
 
       if (response?.lastPage) setLastPage(true)
@@ -49,6 +53,12 @@ const Profile = () => {
   }, [inView, lastPage])
 
   const isPC = useMediaQuery({ query: '(min-width: 834px' })
+
+  const userInfo = useSelector((state: RootState) => state.userInfo)
+
+  // 회원 정보 조회 시 관리자인지 알 수 있는지 확인되어야 함
+  // const advancementFn = async () => {}
+
   return (
     <>
       {isPC ? (
@@ -57,7 +67,7 @@ const Profile = () => {
             <div className="title">
               <span>{memberName}</span> 님의 게시물
             </div>
-            <RoleButton screen="pc">관리자 등록</RoleButton>
+            {userInfo.role === '관리자' && <RoleButton screen="pc">관리자 등록</RoleButton>}
           </TopStyle>
           <Board data={posts} message={'작성한 게시물이 없습니다.'} />
           {!isLoading && <div ref={ref}></div>}
@@ -68,7 +78,7 @@ const Profile = () => {
             <div className="title">
               <span>{memberName}</span> 님의 게시물
             </div>
-            <RoleButton screen="mobile">관리자 등록</RoleButton>
+            {userInfo.role === '관리자' && <RoleButton screen="pc">관리자 등록</RoleButton>}
           </TopStyle>
           <PostContainer>
             {posts?.length ? (


### PR DESCRIPTION
## 🔊 팀원들에게 알릴 사항

- 해당 코드에 타입 에러가 있습니다. 임시적으로 `detailData.boardId || 0` 으로 에러는 막았으나 다른 해결 방안도 찾아 보겠습니다
![image](https://github.com/Field-Passer/newFieldPasser-FE/assets/113992260/d80fa096-44f8-4911-9f7f-33c0a1268470)
- 블라인드 해제 기능은 어떻게 기능을 입혀야 할지 고민 중에 있습니다... ㅠㅠ
- 팝업 기능은 아직 구현 전입니다

## 💸 작업 내용

- #78 
- 문의글 조회 시 페이징을 무한 스크롤로 구현하였습니다.
  - 관리자로 로그인을 한 경우 검색 기능이 없기 때문에 전체적인 내용을 보려면 번거로움이 있을 것 같습니다.
- 게시글 상세 페이지에서 moreBtn 을 관리자, 글 쓴 본인의 경우의 수로 나누어서 코드를 작성하였습니다.
- #46 
- 마이 페이지 3가지 항목 모두 전체 글 수, 페이지네이션 구현하였습니다.
