### PR TITLE
Refactor: 무한스크롤 코드 커스텀훅 분리, 로딩 컴포넌트 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "react-cookie": "^4.1.1",
         "react-datepicker": "^4.15.0",
         "react-dom": "^18.2.0",
-        "react-icons": "^4.10.1",
         "react-intersection-observer": "^9.5.2",
         "react-paginate": "^8.2.0",
         "react-redux": "^8.0.7",
@@ -5386,14 +5385,6 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
       "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ=="
-    },
-    "node_modules/react-icons": {
-      "version": "4.10.1",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.10.1.tgz",
-      "integrity": "sha512-/ngzDP/77tlCfqthiiGNZeYFACw85fUjZtLbedmJ5DTlNDIwETxhwBzdOJ21zj4iJdvc0J3y7yOsX3PpxAJzrw==",
-      "peerDependencies": {
-        "react": "*"
-      }
     },
     "node_modules/react-intersection-observer": {
       "version": "9.5.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "react-cookie": "^4.1.1",
     "react-datepicker": "^4.15.0",
     "react-dom": "^18.2.0",
-    "react-icons": "^4.10.1",
     "react-intersection-observer": "^9.5.2",
     "react-paginate": "^8.2.0",
     "react-redux": "^8.0.7",

--- a/src/api/boardApi.tsx
+++ b/src/api/boardApi.tsx
@@ -22,15 +22,10 @@ export const getSearchPostList = async (values: SearchValueTypes, page = 1) => {
     })
 }
 
-export const getMainPostList = async (values: IMainListPayload, page = 1) => {
-  return await publicApi
-    .get(`/search/${page}?categoryName=${values.category}&districtNames=${values.district}`)
-    .then((res) => {
-      return res.data.data
-    })
-    .catch((err) => {
-      console.log(err)
-    })
+export const getMainPostList = async (params: IMainListPayload, page = 1) => {
+  return await publicApi.get(`/search/${page}`, { params }).then((res) => {
+    return res.data.data
+  })
 }
 
 export const getPostDetail = async (userId: number, loginVal: boolean) => {

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,10 +1,11 @@
+import { GithubIcon } from '@src/constants/icons'
 import PATH from '@src/constants/pathConst'
 import { COLORS } from '@src/globalStyles'
-import { AiFillGithub } from 'react-icons/ai'
 import { useNavigate } from 'react-router'
 import { styled } from 'styled-components'
 
 const Footer = () => {
+  const currentYear = new Date().getFullYear()
   const navigate = useNavigate()
   return (
     <FooterContainer>
@@ -22,7 +23,7 @@ const Footer = () => {
           rel="noopener noreferrer"
           className="link"
         >
-          <AiFillGithub />
+          <GithubIcon />
           Backend Repository
         </a>
         <a
@@ -31,14 +32,14 @@ const Footer = () => {
           rel="noopener noreferrer"
           className="link"
         >
-          <AiFillGithub />
+          <GithubIcon />
           Frontend Repository
         </a>
         <div className="alert">
           필드패서는 통신판매중개자이며 통신판매의 당사자가 아닙니다. 따라서 필드패서는 공간 거래정보 및 거래에 대해
           책임지지 않습니다.
         </div>
-        <span className="copyright">&copy; 2023 FIELD-PASSER. All Rights Reserved.</span>
+        <span className="copyright">&copy; {currentYear} FIELD-PASSER. All Rights Reserved.</span>
       </div>
     </FooterContainer>
   )

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -10,7 +10,7 @@ const Footer = () => {
     <FooterContainer>
       <div className="inner">
         <div className="top">
-          <img src="/logo.png" />
+          <img src="/logo.png" alt="logo" />
           <div className="policy">
             <span onClick={() => navigate(PATH.HELP)}>이용약관</span>
             <span onClick={() => navigate(PATH.HELP)}>운영정책</span>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,6 @@ import { Link, useNavigate } from 'react-router-dom'
 import { COLORS } from '@src/globalStyles'
 import { useMediaQuery } from 'react-responsive'
 import { Mobile } from '@src/hooks/useScreenHook'
-import { FiMenu } from 'react-icons/fi'
 import type { RootState } from '@src/store/config'
 import { DELETE_TOKEN } from '@src/store/slices/authSlice'
 import { useDispatch, useSelector } from 'react-redux'
@@ -13,6 +12,7 @@ import { useEffect, useState } from 'react'
 import { SET_INFO, DELETE_INFO } from '@src/store/slices/infoSlice'
 import PATH from '@src/constants/pathConst'
 import Modal from '@src/components/Modal'
+import { HamburgerIcon } from '@src/constants/icons'
 
 type PropsType = {
   setSideOpen: React.Dispatch<React.SetStateAction<boolean>>
@@ -71,12 +71,14 @@ const Header = ({ setSideOpen }: PropsType) => {
     <>
       <Mobile>
         <MContainer>
-          <FiMenu
+          <div
+            className="sidebar"
             onClick={() => {
               openSidebar()
             }}
-            className="sidebar"
-          />
+          >
+            <HamburgerIcon />
+          </div>
           <img src="/logo.png" alt="logo" onClick={() => navigate(PATH.HOME)} />
         </MContainer>
       </Mobile>
@@ -128,12 +130,14 @@ const MContainer = styled.header`
   border-bottom: 1px solid ${COLORS.gray20};
 
   .sidebar {
-    width: 24px;
-    height: 24px;
-    position: absolute;
-    top: 12px;
-    left: 16px;
-    cursor: pointer;
+    svg {
+      width: 24px;
+      height: 24px;
+      position: absolute;
+      top: 12px;
+      left: 16px;
+      cursor: pointer;
+    }
   }
 
   img {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -86,7 +86,7 @@ const Header = ({ setSideOpen }: PropsType) => {
         <Container>
           <Inner>
             <Link to="/" className="logo">
-              <img src="/logo.png" alt="필드패서" />
+              <img src="/logo.png" alt="logo" />
             </Link>
             <div className="menu">
               {authenticated && userRole === '관리자' && <Link to={PATH.BOARD_BLIND}>게시글 관리</Link>}
@@ -128,6 +128,11 @@ const MContainer = styled.header`
   position: relative;
   background-color: white;
   border-bottom: 1px solid ${COLORS.gray20};
+
+  .logo {
+    width: 160px;
+    height: 24px;
+  }
 
   .sidebar {
     svg {

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,7 +1,6 @@
 import { COLORS } from '@src/globalStyles'
 import { styled } from 'styled-components'
-import { LuInfo } from 'react-icons/lu'
-import { CloseButton } from '@src/constants/icons'
+import { CloseButton, InfoIcon } from '@src/constants/icons'
 import { useMediaQuery } from 'react-responsive'
 import Overlay from './Overlay'
 import { useNavigate } from 'react-router'
@@ -31,7 +30,7 @@ const Modal = ({ modalOpen, setModalOpen, content, isConfirm, navigateOption, co
               <CloseButton />
             </PcButton>
           )}
-          <LuInfo className="info" />
+          <InfoIcon />
           <Content>
             {content.map((text) => {
               return <span key={text}>{text}</span>

--- a/src/components/loading.tsx
+++ b/src/components/loading.tsx
@@ -1,0 +1,53 @@
+import { styled } from 'styled-components'
+import { LoadingIcon } from '../constants/icons'
+import { COLORS } from '@src/globalStyles'
+
+const Loading = () => {
+  return (
+    <LoadingContainer>
+      <div>
+        <LoadingIcon />
+      </div>
+    </LoadingContainer>
+  )
+}
+
+const LoadingContainer = styled.div`
+  width: 50px;
+  height: 50px;
+  margin: 10px auto;
+  color: ${COLORS.green};
+
+  svg {
+    animation: progress-circular-rotate 1.4s linear infinite;
+  }
+  circle {
+    animation: progress-circular-dash 1.4s ease-in-out infinite;
+    fill: transparent;
+    stroke-linecap: round;
+    stroke-dasharray: 80, 200;
+    stroke-dashoffset: 0px;
+    stroke: currentColor;
+  }
+  @keyframes progress-circular-rotate {
+    to {
+      transform: rotate(1turn);
+    }
+  }
+  @keyframes progress-circular-dash {
+    0% {
+      stroke-dasharray: 1, 200;
+      stroke-dashoffset: 0px;
+    }
+    50% {
+      stroke-dasharray: 100, 200;
+      stroke-dashoffset: -15px;
+    }
+    to {
+      stroke-dasharray: 100, 200;
+      stroke-dashoffset: -124px;
+    }
+  }
+`
+
+export default Loading

--- a/src/constants/icons.tsx
+++ b/src/constants/icons.tsx
@@ -323,3 +323,60 @@ export const NoticeIcon = () => {
     </svg>
   )
 }
+
+export const GithubIcon = () => {
+  return (
+    <svg
+      stroke="currentColor"
+      fill="currentColor"
+      strokeWidth="0"
+      viewBox="0 0 1024 1024"
+      height="1em"
+      width="1em"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path d="M511.6 76.3C264.3 76.2 64 276.4 64 523.5 64 718.9 189.3 885 363.8 946c23.5 5.9 19.9-10.8 19.9-22.2v-77.5c-135.7 15.9-141.2-73.9-150.3-88.9C215 726 171.5 718 184.5 703c30.9-15.9 62.4 4 98.9 57.9 26.4 39.1 77.9 32.5 104 26 5.7-23.5 17.9-44.5 34.7-60.8-140.6-25.2-199.2-111-199.2-213 0-49.5 16.3-95 48.3-131.7-20.4-60.5 1.9-112.3 4.9-120 58.1-5.2 118.5 41.6 123.2 45.3 33-8.9 70.7-13.6 112.9-13.6 42.4 0 80.2 4.9 113.5 13.9 11.3-8.6 67.3-48.8 121.3-43.9 2.9 7.7 24.7 58.3 5.5 118 32.4 36.8 48.9 82.7 48.9 132.3 0 102.2-59 188.1-200 212.9a127.5 127.5 0 0 1 38.1 91v112.5c.8 9 0 17.9 15 17.9 177.1-59.7 304.6-227 304.6-424.1 0-247.2-200.4-447.3-447.5-447.3z"></path>
+    </svg>
+  )
+}
+
+export const HamburgerIcon = () => {
+  return (
+    <svg
+      stroke="currentColor"
+      fill="none"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      height="1em"
+      width="1em"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <line x1="3" y1="12" x2="21" y2="12"></line>
+      <line x1="3" y1="6" x2="21" y2="6"></line>
+      <line x1="3" y1="18" x2="21" y2="18"></line>
+    </svg>
+  )
+}
+
+export const InfoIcon = () => {
+  return (
+    <svg
+      stroke="currentColor"
+      fill="none"
+      strokeWidth="2"
+      viewBox="0 0 24 24"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className="info"
+      height="1em"
+      width="1em"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle cx="12" cy="12" r="10"></circle>
+      <line x1="12" x2="12" y1="16" y2="12"></line>
+      <line x1="12" x2="12.01" y1="8" y2="8"></line>
+    </svg>
+  )
+}

--- a/src/constants/icons.tsx
+++ b/src/constants/icons.tsx
@@ -380,3 +380,18 @@ export const InfoIcon = () => {
     </svg>
   )
 }
+
+export const LoadingIcon = () => {
+  return (
+    <svg viewBox="22.857142857142858 22.857142857142858 45.714285714285715 45.714285714285715">
+      <circle
+        cx="45.714285714285715"
+        cy="45.714285714285715"
+        r="20"
+        strokeWidth="5.714285714285714"
+        strokeDasharray="125.664"
+        strokeDashoffset="125.66370614359172px"
+      ></circle>
+    </svg>
+  )
+}

--- a/src/constants/options.ts
+++ b/src/constants/options.ts
@@ -32,3 +32,5 @@ export const sortOptions = ['가장 최신 순', '인기순', '낮은 가격 순
 
 export const times: string[] = ['01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12']
 export const minutes: string[] = ['00', '05', '10', '15', '20', '25', '30', '35', '40', '45', '50', '55']
+
+export const categoryNamesList = 'futsal' || 'soccer' || 'basketball' || 'badminton' || 'tennis'

--- a/src/hooks/useInfinityScroll.tsx
+++ b/src/hooks/useInfinityScroll.tsx
@@ -2,45 +2,35 @@ import { getMainPostList } from '@src/api/boardApi'
 import { useCallback, useEffect, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
 
-const useInfinityScroll = (payload: IMainListPayload) => {
+const useInfinityScroll = (payload: IMainListPayload, page: number, setPage, setPostList) => {
   const [ref, inView] = useInView()
-  const [page, setPage] = useState(1)
   const [isLoading, setIsLoading] = useState(false)
   const [lastPage, setLastPage] = useState(false)
-  const [postList, setPostList] = useState<POST_TYPE[]>([])
 
-  const getPostList = useCallback(async () => {
-    try {
-      setIsLoading(true)
-      const postData = await getMainPostList(payload, page)
-      if (!postData) {
-        setLastPage(true)
-        setPostList([])
-        return setIsLoading(false)
+  const getPostList = useCallback(
+    async (payload, page) => {
+      try {
+        setIsLoading(true)
+        const postData = await getMainPostList(payload, page)
+        if (!postData) {
+          setLastPage(true)
+          setPostList([])
+          return setIsLoading(false)
+        }
+        setPostList((prevList) => [...prevList, ...postData.content])
+        postData.last ? setLastPage(true) : setLastPage(false)
+        console.log('post', page)
+      } catch (error) {
+        alert(error)
+      } finally {
+        setIsLoading(false)
+        console.log(isLoading)
       }
-      setPostList((prevList) => [...prevList, ...postData.content])
-      postData.last ? setLastPage(true) : setLastPage(false)
-      console.log('post', page)
-    } catch (error) {
-      alert(error)
-    } finally {
-      setIsLoading(false)
-    }
-  }, [page, payload])
+    },
+    [page, payload]
+  )
 
-  useEffect(() => {
-    setPostList([])
-    getPostList()
-    setPage(1)
-  }, [payload])
-
-  useEffect(() => {
-    if (inView && !lastPage) {
-      setPage((prev) => prev + 1)
-    }
-  }, [inView, lastPage])
-
-  return { ref, page, isLoading, postList, setPostList }
+  return { lastPage, isLoading, setPostList, getPostList, ref, inView }
 }
 
 export default useInfinityScroll

--- a/src/hooks/useInfinityScroll.tsx
+++ b/src/hooks/useInfinityScroll.tsx
@@ -1,14 +1,14 @@
 import { getMainPostList } from '@src/api/boardApi'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
 
-const useInfinityScroll = (payload: IMainListPayload, page: number, setPage, setPostList) => {
+const useInfinityScroll = ({ payload, page, setPostList }: IInfinityScrollProps) => {
   const [ref, inView] = useInView()
   const [isLoading, setIsLoading] = useState(false)
   const [lastPage, setLastPage] = useState(false)
 
   const getPostList = useCallback(
-    async (payload, page) => {
+    async (payload: IMainListPayload, page: number) => {
       try {
         setIsLoading(true)
         const postData = await getMainPostList(payload, page)
@@ -24,7 +24,6 @@ const useInfinityScroll = (payload: IMainListPayload, page: number, setPage, set
         alert(error)
       } finally {
         setIsLoading(false)
-        console.log(isLoading)
       }
     },
     [page, payload]

--- a/src/hooks/useInfinityScroll.tsx
+++ b/src/hooks/useInfinityScroll.tsx
@@ -1,0 +1,46 @@
+import { getMainPostList } from '@src/api/boardApi'
+import { useCallback, useEffect, useState } from 'react'
+import { useInView } from 'react-intersection-observer'
+
+const useInfinityScroll = (payload: IMainListPayload) => {
+  const [ref, inView] = useInView()
+  const [page, setPage] = useState(1)
+  const [isLoading, setIsLoading] = useState(false)
+  const [lastPage, setLastPage] = useState(false)
+  const [postList, setPostList] = useState<POST_TYPE[]>([])
+
+  const getPostList = useCallback(async () => {
+    try {
+      setIsLoading(true)
+      const postData = await getMainPostList(payload, page)
+      if (!postData) {
+        setLastPage(true)
+        setPostList([])
+        return setIsLoading(false)
+      }
+      setPostList((prevList) => [...prevList, ...postData.content])
+      postData.last ? setLastPage(true) : setLastPage(false)
+      console.log('post', page)
+    } catch (error) {
+      alert(error)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [page, payload])
+
+  useEffect(() => {
+    setPostList([])
+    getPostList()
+    setPage(1)
+  }, [payload])
+
+  useEffect(() => {
+    if (inView && !lastPage) {
+      setPage((prev) => prev + 1)
+    }
+  }, [inView, lastPage])
+
+  return { ref, page, isLoading, postList, setPostList }
+}
+
+export default useInfinityScroll

--- a/src/hooks/useInfinityScroll.tsx
+++ b/src/hooks/useInfinityScroll.tsx
@@ -1,8 +1,8 @@
 import { getMainPostList } from '@src/api/boardApi'
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { useInView } from 'react-intersection-observer'
 
-const useInfinityScroll = ({ payload, page, setPostList }: IInfinityScrollProps) => {
+const useInfinityScroll = ({ payload, page, setPostList, setPage }: IInfinityScrollProps) => {
   const [ref, inView] = useInView()
   const [isLoading, setIsLoading] = useState(false)
   const [lastPage, setLastPage] = useState(false)
@@ -29,7 +29,18 @@ const useInfinityScroll = ({ payload, page, setPostList }: IInfinityScrollProps)
     [page, payload]
   )
 
-  return { lastPage, isLoading, setPostList, getPostList, ref, inView }
+  useEffect(() => {
+    setPage(1)
+    setPostList([])
+  }, [payload])
+
+  useEffect(() => {
+    if (inView && !lastPage) {
+      setPage((prev: number) => prev + 1)
+    }
+  }, [inView, lastPage])
+
+  return { lastPage, isLoading, setPostList, getPostList, ref }
 }
 
 export default useInfinityScroll

--- a/src/hooks/useModal.tsx
+++ b/src/hooks/useModal.tsx
@@ -1,0 +1,5 @@
+const useModal = () => {
+  return <div>useModal</div>
+}
+
+export default useModal

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -15,6 +15,7 @@ import { useMediaQuery } from 'react-responsive'
 import Board from '@src/components/Board'
 import useInfinityScroll from '@src/hooks/useInfinityScroll'
 import { categoryNamesList } from '@src/constants/options'
+import Loading from '@src/components/loading'
 
 const Main = () => {
   const isMobile = useMediaQuery({
@@ -287,6 +288,7 @@ const Main = () => {
         </Options>
         <Board data={postList} message={'일치하는 조건의 게시글이 없습니다.'} />
         {!isLoading && <div ref={ref}></div>}
+        {isLoading && <Loading />}
       </ListSection>
     </Container>
   )

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -14,9 +14,9 @@ import SearchForm from '@src/components/SearchForm'
 import { useMediaQuery } from 'react-responsive'
 import Board from '@src/components/Board'
 import useInfinityScroll from '@src/hooks/useInfinityScroll'
+import { categoryNamesList } from '@src/constants/options'
 
 const Main = () => {
-  const categoryNames = 'futsal' || 'soccer' || 'basketball' || 'badminton' || 'tennis'
   const isMobile = useMediaQuery({
     query: '(max-width: 833px)',
   })
@@ -34,7 +34,24 @@ const Main = () => {
     district: '',
     category: '풋살장',
   })
-  const { ref, isLoading, postList, setPostList } = useInfinityScroll(payload)
+  const [page, setPage] = useState(1)
+  const [postList, setPostList] = useState<POST_TYPE[]>([])
+  const { isLoading, getPostList, lastPage, ref, inView } = useInfinityScroll(payload, page, setPage, setPostList)
+
+  useEffect(() => {
+    setPage(1)
+    setPostList([])
+  }, [payload])
+
+  useEffect(() => {
+    getPostList(payload, page)
+  }, [page, payload])
+
+  useEffect(() => {
+    if (inView && !lastPage) {
+      setPage((prev: number) => prev + 1)
+    }
+  }, [inView, lastPage])
 
   useEffect(() => {
     switch (selectedSortOption) {
@@ -94,6 +111,7 @@ const Main = () => {
           badminton: false,
           tennis: false,
         })
+        setPage(1)
         setPayload({ category: '풋살장', district: payload.district })
         break
       case 'soccer':
@@ -104,6 +122,7 @@ const Main = () => {
           badminton: false,
           tennis: false,
         })
+        setPage(1)
         setPayload({ category: '축구장', district: payload.district })
         break
       case 'basketball':
@@ -114,6 +133,7 @@ const Main = () => {
           badminton: false,
           tennis: false,
         })
+        setPage(1)
         setPayload({ category: '농구장', district: payload.district })
         break
       case 'badminton':
@@ -124,6 +144,7 @@ const Main = () => {
           badminton: true,
           tennis: false,
         })
+        setPage(1)
         setPayload({ category: '배드민턴장', district: payload.district })
         break
       case 'tennis':
@@ -134,6 +155,7 @@ const Main = () => {
           badminton: false,
           tennis: true,
         })
+        setPage(1)
         setPayload({ category: '테니스장', district: payload.district })
         break
     }
@@ -174,7 +196,7 @@ const Main = () => {
                 }}
               >
                 {item.icon}
-                <span className={isActive[item.category as typeof categoryNames] ? 'green' : ''}>{item.name}</span>
+                <span className={isActive[item.category as typeof categoryNamesList] ? 'green' : ''}>{item.name}</span>
               </div>
             )
           })}

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -36,7 +36,7 @@ const Main = () => {
   })
   const [page, setPage] = useState(1)
   const [postList, setPostList] = useState<POST_TYPE[]>([])
-  const { isLoading, getPostList, lastPage, ref, inView } = useInfinityScroll(payload, page, setPage, setPostList)
+  const { isLoading, getPostList, lastPage, ref, inView } = useInfinityScroll({ payload, page, setPostList })
 
   useEffect(() => {
     setPage(1)

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -1,7 +1,7 @@
 import { districtOptions, sortOptions } from '@src/constants/options'
 import { COLORS, FONT } from '@src/globalStyles'
 import { styled } from 'styled-components'
-import { useCallback, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import {
   BadmintonIcon,
   BasketballIcon,
@@ -13,19 +13,13 @@ import {
 import SearchForm from '@src/components/SearchForm'
 import { useMediaQuery } from 'react-responsive'
 import Board from '@src/components/Board'
-import { getMainPostList } from '@src/api/boardApi'
-import { useInView } from 'react-intersection-observer'
+import useInfinityScroll from '@src/hooks/useInfinityScroll'
 
 const Main = () => {
   const categoryNames = 'futsal' || 'soccer' || 'basketball' || 'badminton' || 'tennis'
   const isMobile = useMediaQuery({
     query: '(max-width: 833px)',
   })
-  const [ref, inView] = useInView()
-  const [page, setPage] = useState(1)
-  const [isLoading, setIsLoading] = useState(false)
-  const [lastPage, setLastPage] = useState(false)
-  const [postList, setPostList] = useState<POST_TYPE[]>([])
   const [isDistrictOpen, setIsDistrictOpen] = useState(false)
   const [isSortOpen, setIsSortOpen] = useState(false)
   const [selectedSortOption, setSelectedSortOption] = useState('정렬')
@@ -40,6 +34,7 @@ const Main = () => {
     district: '',
     category: '풋살장',
   })
+  const { ref, isLoading, postList, setPostList } = useInfinityScroll(payload)
 
   useEffect(() => {
     switch (selectedSortOption) {
@@ -60,42 +55,6 @@ const Main = () => {
         break
     }
   }, [selectedSortOption])
-
-  const getPostList = useCallback(async () => {
-    try {
-      setIsLoading(true)
-      const postData = await getMainPostList(payload, page)
-      if (!postData) {
-        setLastPage(true)
-        setPostList([])
-        return setIsLoading(false)
-      }
-      setPostList((prevList) => [...prevList, ...postData.content])
-      postData.last ? setLastPage(true) : setLastPage(false)
-    } catch (error) {
-      alert(error)
-    } finally {
-      setIsLoading(false)
-    }
-  }, [page, payload])
-
-  useEffect(() => {
-    setPostList([])
-    getPostList()
-    setPage(1)
-  }, [payload])
-
-  useEffect(() => {
-    if (inView && !lastPage) {
-      setPage((prev) => prev + 1)
-    }
-  }, [inView, lastPage])
-
-  useEffect(() => {
-    if (page !== 1) {
-      getPostList()
-    }
-  }, [getPostList])
 
   const categories: ICategories[] = [
     {

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -32,27 +32,16 @@ const Main = () => {
     tennis: false,
   })
   const [payload, setPayload] = useState({
-    district: '',
-    category: '풋살장',
+    districtName: '',
+    categoryName: '풋살장',
   })
   const [page, setPage] = useState(1)
   const [postList, setPostList] = useState<POST_TYPE[]>([])
-  const { isLoading, getPostList, lastPage, ref, inView } = useInfinityScroll({ payload, page, setPostList })
-
-  useEffect(() => {
-    setPage(1)
-    setPostList([])
-  }, [payload])
+  const { isLoading, getPostList, ref } = useInfinityScroll({ payload, page, setPostList, setPage })
 
   useEffect(() => {
     getPostList(payload, page)
   }, [page, payload])
-
-  useEffect(() => {
-    if (inView && !lastPage) {
-      setPage((prev: number) => prev + 1)
-    }
-  }, [inView, lastPage])
 
   useEffect(() => {
     switch (selectedSortOption) {
@@ -112,8 +101,7 @@ const Main = () => {
           badminton: false,
           tennis: false,
         })
-        setPage(1)
-        setPayload({ category: '풋살장', district: payload.district })
+        setPayload({ categoryName: '풋살장', districtName: payload.districtName })
         break
       case 'soccer':
         setIsActive({
@@ -123,8 +111,7 @@ const Main = () => {
           badminton: false,
           tennis: false,
         })
-        setPage(1)
-        setPayload({ category: '축구장', district: payload.district })
+        setPayload({ categoryName: '축구장', districtName: payload.districtName })
         break
       case 'basketball':
         setIsActive({
@@ -134,8 +121,7 @@ const Main = () => {
           badminton: false,
           tennis: false,
         })
-        setPage(1)
-        setPayload({ category: '농구장', district: payload.district })
+        setPayload({ categoryName: '농구장', districtName: payload.districtName })
         break
       case 'badminton':
         setIsActive({
@@ -145,8 +131,7 @@ const Main = () => {
           badminton: true,
           tennis: false,
         })
-        setPage(1)
-        setPayload({ category: '배드민턴장', district: payload.district })
+        setPayload({ categoryName: '배드민턴장', districtName: payload.districtName })
         break
       case 'tennis':
         setIsActive({
@@ -156,8 +141,7 @@ const Main = () => {
           badminton: false,
           tennis: true,
         })
-        setPage(1)
-        setPayload({ category: '테니스장', district: payload.district })
+        setPayload({ categoryName: '테니스장', districtName: payload.districtName })
         break
     }
   }
@@ -213,7 +197,7 @@ const Main = () => {
               >
                 <div
                   className="default option"
-                  onClick={() => setPayload({ district: '', category: payload.category })}
+                  onClick={() => setPayload({ districtName: '', categoryName: payload.categoryName })}
                 >
                   지역
                 </div>
@@ -223,7 +207,7 @@ const Main = () => {
                       key={item}
                       className="option"
                       onClick={() => {
-                        setPayload({ district: item, category: payload.category })
+                        setPayload({ districtName: item, categoryName: payload.categoryName })
                       }}
                     >
                       {item}
@@ -233,12 +217,12 @@ const Main = () => {
               </div>
             ) : (
               <button
-                className={payload.district !== '' ? 'select-close selected' : 'select-close'}
+                className={payload.districtName !== '' ? 'select-close selected' : 'select-close'}
                 onClick={() => {
                   setIsDistrictOpen(true)
                 }}
               >
-                {payload.district ? payload.district : '지역'}
+                {payload.districtName ? payload.districtName : '지역'}
                 <DownwardArrowIcon />
               </button>
             )}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -90,8 +90,8 @@ interface SearchValueTypes {
 }
 
 interface IMainListPayload {
-  district: string
-  category: string
+  districtName: string
+  categoryName: string
 }
 
 interface ValueStateType {
@@ -221,14 +221,5 @@ interface IInfinityScrollProps {
   payload: SearchValueTypes | IMainListPayload
   page: number
   setPostList: React.Dispatch<React.SetStateAction<POST_TYPE[]>>
-  // title: string
-  // startDate: string
-  // endDate: string
-  // startTime: string
-  // endTime: string
-  // district: string[]
-  // category: string
-  // chkDate: boolean
-  // // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  // [prop: string]: any
+  setPage: React.Dispatch<React.SetStateAction<number>>
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -216,3 +216,19 @@ interface CustomDateInputProps {
   value: ''
   onClick: () => void
 }
+
+interface IInfinityScrollProps {
+  payload: SearchValueTypes | IMainListPayload
+  page: number
+  setPostList: React.Dispatch<React.SetStateAction<POST_TYPE[]>>
+  // title: string
+  // startDate: string
+  // endDate: string
+  // startTime: string
+  // endTime: string
+  // district: string[]
+  // category: string
+  // chkDate: boolean
+  // // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // [prop: string]: any
+}


### PR DESCRIPTION
## 🔊 팀원들에게 알릴 사항

- 메인페이지 무한스크롤 커스텀 훅으로 분리했습니다. 
- 현재 props 타입, api코드는 메인페이지 기준으로 임시 지정되어있습니다. 다른 페이지에도 적용하려면 수정이 필요합니다.
- 로딩 컴포넌트가 추가되었습니다. 필요한 페이지에서 사용해주세요.

## 💸 작업 내용

- 작업 개요(#96 )
- 무한스크롤 커스텀 훅 분리
- 일부 아이콘 svg코드로 저장, react-icons 라이브러리 삭제
- 로딩 컴포넌트 추가
