### PR TITLE
Feat: 회원탈퇴 api 추가 및 사이드바 버튼 연결

### DIFF
--- a/src/api/authApi.tsx
+++ b/src/api/authApi.tsx
@@ -43,3 +43,9 @@ export async function postRefereshToken() {
     console.log(error)
   }
 }
+
+// 회원 탈퇴
+export const userWithdrawal = async () => {
+  const response = await privateApi.delete('/my-page/withdrawal')
+  return response
+}

--- a/src/components/Main/Sidebar.tsx
+++ b/src/components/Main/Sidebar.tsx
@@ -10,6 +10,8 @@ import PATH from '@src/constants/pathConst'
 import useSidebar from '@src/hooks/useSidebar'
 import useLoginState from '@src/hooks/useLoginState'
 import { BoldCloseIcon, MyCommentIcon, MyHeartIcon, MyPageIcon, MyPostIcon } from '@src/constants/icons'
+import { userWithdrawal } from '@src/api/authApi'
+import useModal from '@src/hooks/useModal'
 
 const Sidebar = () => {
   const isMobile = useMediaQuery({
@@ -19,6 +21,7 @@ const Sidebar = () => {
   const { isSidebarOpen } = useSelector((state: RootState) => state.sidebar)
   const { closeSidebar } = useSidebar()
   const { accessAfterLoginAlert, logoutHandler } = useLoginState()
+  const { openModal } = useModal()
 
   useEffect(() => {
     if (!isMobile) {
@@ -29,6 +32,27 @@ const Sidebar = () => {
   const userName = useSelector((state: RootState) => state.userInfo.memberName)
   const userRole = useSelector((state: RootState) => state.userInfo.role)
   const refreshToken = getCookieToken()
+
+  const deleteAccount = async () => {
+    try {
+      const response = await userWithdrawal()
+      if (response.status === 200) {
+        logoutHandler()
+        openModal({
+          isModalOpen: true,
+          isConfirm: false,
+          content: ['회원탈퇴에 성공했습니다.'],
+          navigateOption: PATH.HOME,
+        })
+      }
+    } catch (error) {
+      openModal({
+        isModalOpen: true,
+        isConfirm: false,
+        content: ['회원탈퇴에 실패했습니다. 고객센터로 문의해주세요.'],
+      })
+    }
+  }
 
   return (
     <SideContainer id="sidebar" className={isSidebarOpen && isMobile ? 'open' : ''}>
@@ -174,7 +198,7 @@ const Sidebar = () => {
           >
             로그아웃
           </div>
-          <div className="blur" onClick={() => console.log('회원탈퇴')}>
+          <div className="blur" onClick={() => deleteAccount()}>
             회원탈퇴
           </div>
         </LastSection>


### PR DESCRIPTION


## 🔊 팀원들에게 알릴 사항

- 그러나 작동은 하지 않고 로그아웃 버튼처럼 동작합니다..
- api 문의 후 수정사항 생기는대로 수정해서 올리겠습니다.

## 💸 작업 내용

- 회원탈퇴api(/mypage/withdrawal) 추가
- 사이드바의 회원탈퇴 버튼에 연결
